### PR TITLE
updated to 0.5.1 create and added truename patch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 # Mod Info
 maven_group = ca.objectobject.hexxycraft
 archives_base_name = hexxytweaks
-mod_version = 0.1.1
+mod_version = 0.1.2
 
 minecraft_version = 1.19.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ parchment_version = 2022.11.27
 
 # Create
 # https://modrinth.com/mod/create-fabric/versions
-create_version = 0.5.0.i-1017+1.19.2
+create_version = 0.5.1-b-build.1089+mc1.19.2
 
 # Development QOL
 # Create supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.

--- a/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/common/LadderPlacementHelper.java
+++ b/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/common/LadderPlacementHelper.java
@@ -27,10 +27,10 @@ package ca.objectobject.hexxycraft.hexxytweaks.common;
 import java.util.function.Predicate;
 
 import com.jamieswhiteshirt.reachentityattributes.ReachEntityAttributes;
-import com.simibubi.create.content.curiosities.tools.ExtendoGripItem;
-import com.simibubi.create.foundation.config.AllConfigs;
-import com.simibubi.create.foundation.utility.placement.IPlacementHelper;
-import com.simibubi.create.foundation.utility.placement.PlacementOffset;
+import com.simibubi.create.content.equipment.extendoGrip.ExtendoGripItem;
+import com.simibubi.create.foundation.placement.IPlacementHelper;
+import com.simibubi.create.foundation.placement.PlacementOffset;
+import com.simibubi.create.infrastructure.config.AllConfigs;
 
 import net.minecraft.MethodsReturnNonnullByDefault;
 import net.minecraft.core.BlockPos;
@@ -42,9 +42,8 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.phys.BlockHitResult;
-
-import static net.minecraft.world.level.block.LadderBlock.FACING;
 
 /**
  * Code directly copied from Create since I couldn't figure out how to get access to it.
@@ -80,7 +79,7 @@ public class LadderPlacementHelper implements IPlacementHelper {
 									 BlockHitResult ray) {
 		Direction dir = player.getXRot() < 0 ? Direction.UP : Direction.DOWN;
 
-		int range = AllConfigs.SERVER.curiosities.placementAssistRange.get();
+		int range = AllConfigs.server().equipment.placementAssistRange.get();
 		if (player != null) {
 			AttributeInstance reach = player.getAttribute(ReachEntityAttributes.REACH);
 			if (reach != null && reach.hasModifier(ExtendoGripItem.singleRangeAttributeModifier))
@@ -98,7 +97,7 @@ public class LadderPlacementHelper implements IPlacementHelper {
 			return PlacementOffset.fail();
 
 		if (newState.getMaterial().isReplaceable())
-			return PlacementOffset.success(newPos, bState -> bState.setValue(FACING, state.getValue(FACING)));
+			return PlacementOffset.success(newPos, bState -> bState.setValue(BlockStateProperties.FACING, state.getValue(BlockStateProperties.FACING)));
 		return PlacementOffset.fail();
 	}
 

--- a/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/BlockBehaviourMixin.java
+++ b/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/BlockBehaviourMixin.java
@@ -1,5 +1,10 @@
 package ca.objectobject.hexxycraft.hexxytweaks.mixin;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.InteractionHand;
@@ -7,15 +12,8 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockBehaviour;
-
 import net.minecraft.world.level.block.state.BlockState;
-
 import net.minecraft.world.phys.BlockHitResult;
-
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 // https://www.fabricmc.net/wiki/tutorial:mixinheritance
 @Mixin(BlockBehaviour.class)

--- a/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/LadderBlockMixin.java
+++ b/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/LadderBlockMixin.java
@@ -24,12 +24,14 @@ SOFTWARE.
 
 package ca.objectobject.hexxycraft.hexxytweaks.mixin;
 
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.simibubi.create.content.equipment.wrench.IWrenchable;
+import com.simibubi.create.foundation.placement.IPlacementHelper;
+import com.simibubi.create.foundation.placement.PlacementHelpers;
+
 import ca.objectobject.hexxycraft.hexxytweaks.common.LadderPlacementHelper;
-
-import com.simibubi.create.content.contraptions.wrench.IWrenchable;
-import com.simibubi.create.foundation.utility.placement.IPlacementHelper;
-import com.simibubi.create.foundation.utility.placement.PlacementHelpers;
-
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.core.BlockPos;
@@ -43,9 +45,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.LadderBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.BlockHitResult;
-
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 
 /**

--- a/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/MetalLadderBlockPlacementHelperMixin.java
+++ b/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/MetalLadderBlockPlacementHelperMixin.java
@@ -24,22 +24,21 @@ SOFTWARE.
 
 package ca.objectobject.hexxycraft.hexxytweaks.mixin;
 
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.ItemStack;
-
-import net.minecraft.world.level.block.LadderBlock;
+import java.util.function.Predicate;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
-import java.util.function.Predicate;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.LadderBlock;
 
 /**
  * Overrides the item predicate to allow extending metal ladders with vanilla ones.
  */
-@Mixin(targets = "com.simibubi.create.content.curiosities.deco.MetalLadderBlock$PlacementHelper", remap = false)
+@Mixin(targets = "com.simibubi.create.content.decoration.MetalLadderBlock$PlacementHelper", remap = false)
 public abstract class MetalLadderBlockPlacementHelperMixin {
 
 	@Inject(method = "getItemPredicate", at = @At("RETURN"), cancellable = true)

--- a/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/TruenameProtectionActMixin.java
+++ b/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/TruenameProtectionActMixin.java
@@ -4,7 +4,9 @@ import java.util.UUID;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.simibubi.create.content.kinetics.deployer.DeployerFakePlayer;
 
@@ -17,9 +19,9 @@ public class TruenameProtectionActMixin {
     private static UUID nullifyUUID(UUID owner){
         return null;
     }
-    // @Inject (method="<init>(Lnet/minecraft/server/level/ServerLevel;Ljava/util/UUID;)V", 
-    //     at=@At("HEAD"))
-    // private static void nullifyUUID(CallbackInfo ci, @Local LocalRef<UUID> ownerRef){
-    //     ownerRef.set(null);
-    // }
+
+    @Inject(method="getUUID()Ljava/util/UUID;", at=@At("HEAD"), cancellable=true)
+    private void redirectGetUuid(CallbackInfoReturnable<UUID> cir){
+        cir.setReturnValue(DeployerFakePlayer.fallbackID);
+    }
 }

--- a/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/TruenameProtectionActMixin.java
+++ b/src/main/java/ca/objectobject/hexxycraft/hexxytweaks/mixin/TruenameProtectionActMixin.java
@@ -1,0 +1,25 @@
+package ca.objectobject.hexxycraft.hexxytweaks.mixin;
+
+import java.util.UUID;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.simibubi.create.content.kinetics.deployer.DeployerFakePlayer;
+
+// mixin to deployer fake player class to force it to use its fallback uuid rather than the player one passed to it
+// maybe better way to balance this? perhaps using a focus on it would let it actually have that uuid, but that's too much work for now
+@Mixin(DeployerFakePlayer.class)
+public class TruenameProtectionActMixin {
+    @ModifyArg (method="<init>(Lnet/minecraft/server/level/ServerLevel;Ljava/util/UUID;)V", index=2,
+        at=@At(value="INVOKE", target="com/simibubi/create/content/kinetics/deployer/DeployerFakePlayer$DeployerGameProfile.<init> (Ljava/util/UUID;Ljava/lang/String;Ljava/util/UUID;)V"))
+    private static UUID nullifyUUID(UUID owner){
+        return null;
+    }
+    // @Inject (method="<init>(Lnet/minecraft/server/level/ServerLevel;Ljava/util/UUID;)V", 
+    //     at=@At("HEAD"))
+    // private static void nullifyUUID(CallbackInfo ci, @Local LocalRef<UUID> ownerRef){
+    //     ownerRef.set(null);
+    // }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -5,7 +5,8 @@
   "name": "HexxyTweaks",
   "description": "Tweaks for the HexxyCraft modpack.",
   "authors": [
-    "object-Object"
+    "object-Object",
+    "samsthenerd"
   ],
   "contact": {
     "sources": "https://github.com/HexxyCraft/HexxyTweaks"
@@ -29,7 +30,7 @@
   },
   "custom": {
     "loom:injected_interfaces": {
-      "net/minecraft/class_2399": ["com/simibubi/create/content/contraptions/wrench/IWrenchable"]
+      "net/minecraft/class_2399": ["com/simibubi/create/content/equipment/wrench/IWrenchable"]
     }
   }
 }

--- a/src/main/resources/hexxytweaks.mixins.json
+++ b/src/main/resources/hexxytweaks.mixins.json
@@ -6,7 +6,8 @@
   "mixins": [
     "BlockBehaviourMixin",
     "LadderBlockMixin",
-    "MetalLadderBlockPlacementHelperMixin"
+    "MetalLadderBlockPlacementHelperMixin",
+    "TruenameProtectionActMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
truename patch just forces deployer fake players to use the fallback uuid instead of the players. tested with a toolsmith circle, it activated it without the patch but fails with the patch.